### PR TITLE
Fixed migration that removed unneeded fields from reports table

### DIFF
--- a/app/Config/Migration/1375798518_remove_unneeded_fields_form_reports.php
+++ b/app/Config/Migration/1375798518_remove_unneeded_fields_form_reports.php
@@ -19,17 +19,16 @@ class RemoveUnneededFieldsFormReports extends CakeMigration {
 		'up' => array(
 			'create_field' => array(
 				'reports' => array(
-					'location' => array('type' => 'text', 'null' => false, 'default' => NULL, 'collate' => 'utf8_general_ci', 'charset' => 'utf8', 'after' => 'status'),
 					'related_to' => array('type' => 'integer', 'null' => true, 'default' => NULL, 'length' => 10, 'after' => 'sourceforge_bug_id'),
 				),
 			),
 			'drop_field' => array(
-				'reports' => array('php_version', 'browser', 'user_os', 'server_software', 'steps', 'stacktrace', 'full_report', 'related_report_id', 'filename',),
+				'reports' => array('php_version', 'browser', 'user_os', 'server_software', 'steps', 'stacktrace', 'full_report', 'related_report_id',),
 			),
 		),
 		'down' => array(
 			'drop_field' => array(
-				'reports' => array('location', 'related_to',),
+				'reports' => array('related_to',),
 			),
 			'create_field' => array(
 				'reports' => array(
@@ -41,7 +40,6 @@ class RemoveUnneededFieldsFormReports extends CakeMigration {
 					'stacktrace' => array('type' => 'text', 'null' => true, 'default' => NULL, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 					'full_report' => array('type' => 'text', 'null' => true, 'default' => NULL, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 					'related_report_id' => array('type' => 'integer', 'null' => true, 'default' => NULL, 'length' => 10),
-					'filename' => array('type' => 'text', 'null' => false, 'default' => NULL, 'collate' => 'utf8_general_ci', 'charset' => 'utf8'),
 				),
 			),
 		),

--- a/app/Model/Incident.php
+++ b/app/Model/Incident.php
@@ -96,7 +96,7 @@ class Incident extends AppModel {
 	}
 
 	protected function _getSchematizedIncident($bugReport) {
-    $bugReport = Sanitize::clean($bugReport);
+		$bugReport = Sanitize::clean($bugReport);
 		$schematizedReport = array(
 			'pma_version' => $bugReport['pma_version'],
 			'php_version' => $this->_getSimplePhpVersion($bugReport['php_version']),
@@ -177,7 +177,10 @@ class Incident extends AppModel {
 			$levelB = $stacktraceB[$i];
 			$elements = array("filename", "scriptname", "line", "func", "column");
 			foreach ($elements as $element) {
-				if($levelA[$element] !== $levelB[$element]) {
+				if (isset($levelA[$element]) xor isset($levelB[$element])) {
+					return false;
+				}
+				if ($levelA[$element] !== $levelB[$element]) {
 					return false;
 				}
 			}


### PR DESCRIPTION
This fixes an old migration that has already been committed. This is something that I set out to never to do since this can cause problems in a production environment. Luckily this is just a staging environment but this issue exposed a problem in the way deployment occurs. I will have to think of a way to avoid this in the future but  for now this should fix the problem.

To apply this fix in the staging environment you can try to run the migrations again and see if it works otherwise you would have to drop all the tables and run all migrations again which should work.
