### PR TITLE
Add 'unlink' feature.

### DIFF
--- a/app/View/Reports/view.ctp
+++ b/app/View/Reports/view.ctp
@@ -50,13 +50,25 @@
       echo $this->Html->link('#' . $report['Report']['sourceforge_bug_id'],
           "https://sourceforge.net/p/$project_name/bugs/".
           $report['Report']['sourceforge_bug_id'] . "/");
+      echo '<form action="'
+          . Router::url('/source_forge/unlink_ticket/', true)
+          . $report['Report']['id']
+          .'" method="GET" class="form-horizontal" style="margin-bottom:5px;"'
+          . ' onclick="return window.confirm(\'Are you sure you want to unlink??\');" >';
+      echo $this->Form->input('UnLink with Ticket', array(
+        'type' => 'submit',
+        'label' => false,
+        'class'=>'btn btn-primary'
+        )
+      );
+      echo '</form>';
     } else {
       echo '<table cellspacing="0" class="table table-bordered error-report"'
           . ' style="width:300px; margin-bottom:5px;">'
           . '<tr><td style="min-width:130px;">';
       echo $this->Html->link('Create New Ticket', '/source_forge/create_ticket/'
           . $report['Report']['id']);
-      
+
       echo '</td><td style="min-width:130px;">';
 
       echo '<form action="'


### PR DESCRIPTION
Signed-off-by: Dhananjay Nakrani dhananjaynakrani@gmail.com

Many a times the developer may have to **_unlink**_ the Error Report from associated SF Bug ticket. Say in case when Error Report was linked with wrong Bug Ticket OR after linking the developer learns that they're not related to each other at all.

On the Report's individual view, a button is displayed for unlinking. 
![screenshot-3](https://cloud.githubusercontent.com/assets/6269279/3395243/b645e862-fcf9-11e3-8dbf-de879f120285.png)

Clicking on it will ask user for confirmation. If user says 'OK' then it removes the empties `sourceforge_bug_id` of that report as well as posts a comment on the associated Bug Ticket on SF.
![screenshot-2](https://cloud.githubusercontent.com/assets/6269279/3395252/faea2b4a-fcf9-11e3-9f8c-9799145e831e.png)

_This was not proposed as part of GSoC project. But I realized it was an important feature. So did it._:smiley:
