### PR TITLE
Cakephp3.0 migration

### DIFF
--- a/webroot/robots.txt
+++ b/webroot/robots.txt
@@ -1,0 +1,5 @@
+User-agent: Google
+Disallow:
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
added robots.txt. It should fix the issue https://github.com/phpmyadmin/error-reporting-server/issues/80. I have allowed only Google to be able to crawl. We can change if needed.