### PR TITLE
Enable state maintenance and fix ctrl-click/middle-click issue

### DIFF
--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -281,20 +281,15 @@ class ReportsController extends AppController {
 	}
 
 	/**
-	 * Indexes are +1'ed because first column is of checkboxes
-	 * and hence it should be ingnored.
 	 * @param string[] $aColumns
 	 */
 	protected function _getOrder($aColumns) {
 		if ( $this->request->query('iSortCol_0') != null ) {
 			$order = [];
-			for ( $i = 0; $i < intval($this->request->query('iSortingCols')); $i++ ) {
-				if ( $this->request->query('bSortable_'
-						. intval($this->request->query('iSortCol_' . ($i+1)))) == "true" ) {
-					$order[$aColumns[intval($this->request->query('iSortCol_' . ($i+1)))]]
-							= $this->request->query('sSortDir_' . $i);
-					
-				}
+			//Seems like we need to sort with only one column each time, so no need to loop
+			$sort_column_index = intval($this->request->query('iSortCol_0'));
+			if ($this->request->query('bSortable_' . $sort_column_index) == "true") {
+				$order[$aColumns[$sort_column_index - 1]] = $this->request->query('sSortDir_0');
 			}
 			return $order;
 		} else {

--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -288,7 +288,7 @@ class ReportsController extends AppController {
 			$order = [];
 			//Seems like we need to sort with only one column each time, so no need to loop
 			$sort_column_index = intval($this->request->query('iSortCol_0'));
-			if ($this->request->query('bSortable_' . $sort_column_index) == "true") {
+			if ($sort_column_index > 0 && $this->request->query('bSortable_' . $sort_column_index) == "true") {
 				$order[$aColumns[$sort_column_index - 1]] = $this->request->query('sSortDir_0');
 			}
 			return $order;

--- a/webroot/js/custom.js
+++ b/webroot/js/custom.js
@@ -41,9 +41,14 @@ $(document).ready(function () {
 		},
 		"fnRowCallback": function( nRow, aData, iDisplayIndex ) {
 			// click on the row anywhere to go to the report.
-			$(nRow).click(function () {
-				// extract the href from the anchor string
-				document.location.href = $($.parseHTML(aData[1])).attr('href');
+			$(nRow).click(function (event) {
+				if (event.ctrlKey || event.which == 2) {
+					event.stopPropagation();
+				} else {
+					// extract the href from the anchor string
+					var url = $($.parseHTML(aData[1])).attr('href');
+					document.location.href = url;
+				}
 			});
 		}
 	});

--- a/webroot/js/custom.js
+++ b/webroot/js/custom.js
@@ -3,6 +3,7 @@ $(document).ready(function () {
 		"bSortCellsTop": true,
 		"bProcessing": true,
 		"bServerSide": true,
+		"bStateSave": true,
 		"sAjaxSource": $('#reports_table').data('ajax-url'),
 		"aoColumnDefs": [
 			{ "bSearchable": false, "aTargets": [ 1, 6 ] },


### PR DESCRIPTION
Using built in mechanism of DataTables, state is now maintained on reports list page, on refresh or going back/forth from some other page.
Also issue https://github.com/phpmyadmin/error-reporting-server/issues/85 should be fixed, tested on Chrome/Firefox.

TODO: after refresh/back/forth, the filter selectors on reports page need to reflect the current state.