### PR TITLE
clean old notification shell for cron

### DIFF
--- a/src/Controller/NotificationsController.php
+++ b/src/Controller/NotificationsController.php
@@ -93,7 +93,7 @@ public $components = array('RequestHandler');
 		);
 		$this->autoRender = false;
         $this->response->body(json_encode($response));
-        return $this->response;	
+        return $this->response;
      }
 
 	/**
@@ -119,29 +119,5 @@ public $components = array('RequestHandler');
 		}
 		$this->Flash->default($msg, array("class" => $flash_class));
 		$this->redirect("/notifications/");
-	}
-
-	/**
-	 * Cron Action to clean older Notifications.
-	 * Can not (& should not) be directly accessed via Web.
-	 */
-	public function clean_old_notifs()
-	{
-		if (!defined('CRON_DISPATCHER')) {
-			$this->redirect('/');
-			exit();
-		}
-		// X Time: All the notifications before this time are to be deleted.
-		// Currently it's set to 60 days from current time.
-		$XTime = time() - 60*24*3600;
-		$conditions = array('Notifications.created <' => date('Y-m-d H:i:s', $XTime));
-		if (!$this->Notifications->deleteAll($conditions)) {
-			Log::write(
-				'cron_jobs',
-				'FAILED: Deleting older Notifications!!',
-				'cron_jobs'
-			);
-		}
-		$this->autoRender = false;
 	}
 }

--- a/src/Shell/CleanOldNotifsShell.php
+++ b/src/Shell/CleanOldNotifsShell.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Shell;
+
+use Cake\Console\Shell;
+use Cake\Log\Log;
+
+class CleanOldNotifsShell extends Shell
+{
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadModel('Notifications');
+    }
+    public function main()
+    {
+        $XTime = time() - 60*24*3600;
+		$conditions = array('Notifications.created <' => date('Y-m-d H:i:s', $XTime));
+		if (!$this->Notifications->deleteAll($conditions)) {
+			Log::write(
+				'error',
+				'FAILED: Deleting older Notifications!!',
+				'cron_jobs'
+			);
+		}
+    }
+}

--- a/tests/TestCase/Controller/NotificationsControllerTest.php
+++ b/tests/TestCase/Controller/NotificationsControllerTest.php
@@ -42,27 +42,4 @@ class NotificationsControllerTest extends IntegrationTestCase {
         );
 		$this->assertEquals($actual, $expected);
 	}
-
-	public function testCleanOldNotifs() {
-		// Mark one Notification as "not older". Setting 'created' to current time.
-		$notification = $this->Notifications->get(3);
-		$notification->created= date('Y-m-d H:i:s', time());
-		$this->Notifications->save($notification);
-
-		// define constant for Cron Jobs
-		if (!defined('CRON_DISPATCHER')) {
-			define('CRON_DISPATCHER', true);
-		}
-		$this->get('/notifications/clean_old_notifs');
-		$notifications = $this->Notifications->find('all', array('fields' => array('Notifications.id')));
-        $this->assertInstanceOf('Cake\ORM\Query', $notifications);
-        $actual = $notifications->hydrate(false)->toArray();
-		$expected = array(
-			array(
-				'id' => "3"
-            )
-		);
-
-		$this->assertEquals($actual, $expected);
-	}
 }


### PR DESCRIPTION
command to use to setup cron job: 
`bin/cake clean_old_notifs`
this will delete notifications which are older than 2 months.