### PR TITLE
Restore current state of filter selectors on reports page

### DIFF
--- a/webroot/js/custom.js
+++ b/webroot/js/custom.js
@@ -50,6 +50,17 @@ $(document).ready(function () {
 					document.location.href = url;
 				}
 			});
+		},
+		"fnInitComplete": function(oSettings) {
+			$(this.find("select")).each( function(index) {
+				if (index == 0 && oSettings.aoPreSearchCols[index+2].sSearch.length>0) {
+					// Exception Name selector
+					$(this).val(oSettings.aoPreSearchCols[index+2].sSearch);
+				} else if (oSettings.aoPreSearchCols[index+3].sSearch.length>0) {
+					//Other selectors
+					$(this).val(oSettings.aoPreSearchCols[index+3].sSearch);
+				}
+			});
 		}
 	});
 


### PR DESCRIPTION
I believe it completes the fix for https://github.com/phpmyadmin/error-reporting-server/issues/25

Signed-off-by: Atul Pratap Singh <atulpratapsingh05@gmail.com>