### PR TITLE
Attempted fix for issue #81

### DIFF
--- a/src/Template/Reports/view.ctp
+++ b/src/Template/Reports/view.ctp
@@ -14,9 +14,9 @@
 			$report[0]["status"], 'empty' => false)); ?>
 	<input type="submit" value="Change" class="btn btn-primary" />
 </form>
-<?php if (empty($related_reports)) { ?>
+<?php if ($related_reports->isEmpty()) { ?>
 <form class="form-inline" action="/<?php echo BASE_DIR ?>reports/mark_related_to/<?php
-      echo $report["Report"]["id"]; ?>">
+      echo $report[0]["id"]; ?>">
     <span>Mark the same as:</span>
     <input type="number" min="1" name="related_to" />
     <input type="submit" value="Submit" class="btn btn-primary" />


### PR DESCRIPTION
Attempted fix for issue #81 : Grouping no longer works

CakePHP3-way for checking if a resultset or a query object is empty or not is `$query->isEmpty();`.
http://book.cakephp.org/3.0/en/orm/retrieving-data-and-resultsets.html#checking-if-a-query-or-resultset-is-empty

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>