### PR TITLE
Fix #100 : Redirect to home page when not logged in

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -108,6 +108,6 @@ class AppController extends Controller {
 
 		$this->Flash->default("You need to be signed in to do this");
 		$this->request->session()->write("last_page", $this->here);
-		return $this->redirect($this->referer());
+		return $this->redirect("/");
 	}
 }


### PR DESCRIPTION
Redirect to home page when 'not logged in', instead of the referer.

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>