### PR TITLE
Log extremely long reports and don't save them

### DIFF
--- a/tests/TestCase/Model/Table/IncidentsTableTest.php
+++ b/tests/TestCase/Model/Table/IncidentsTableTest.php
@@ -359,6 +359,32 @@ class IncidentsTableTest extends TestCase
         $result = TableRegistry::get('Incidents')->find('all', array('conditions' => array('report_id = ' . $incident->report_id)));
         $result = $result->hydrate(false)->toArray();
         $this->assertEquals(2, count($result));
+
+
+        // Case 3.1: Long PHP report submission
+        $bugReport = file_get_contents(TESTS . 'Fixture' . DS . 'report_php.json');
+        $bugReport = json_decode($bugReport, true);
+
+        // Forcefully inflate the report by inflating $bugReport['errors']
+        for ($i = 0; $i < 2000; $i++) {
+            $bugReport['errors'] = array_push($bugReport['errors'], $bugReport['errors'][0]);
+        }
+        $result = $this->Incidents->createIncidentFromBugReport($bugReport);
+
+        $this->assertEquals(true, in_array(false, $result));
+
+
+        // Case 3.2: Long JS report submission
+        $bugReport = file_get_contents(TESTS . 'Fixture' . DS . 'report_js.json');
+        $bugReport = json_decode($bugReport, true);
+
+        // Forcefully inflate the report by inflating $bugReport['errors']
+        for ($i = 0; $i < 1500; $i++) {
+            $bugReport['exception']['stack'] .= array_push($bugReport['exception']['stack'][0]);
+        }
+        $result = $this->Incidents->createIncidentFromBugReport($bugReport);
+
+        $this->assertEquals(true, in_array(false, $result));
     }
 
     /**

--- a/tests/TestCase/Model/Table/IncidentsTableTest.php
+++ b/tests/TestCase/Model/Table/IncidentsTableTest.php
@@ -367,7 +367,7 @@ class IncidentsTableTest extends TestCase
 
         // Forcefully inflate the report by inflating $bugReport['errors']
         for ($i = 0; $i < 2000; $i++) {
-            $bugReport['errors'] = array_push($bugReport['errors'], $bugReport['errors'][0]);
+            $bugReport['errors'][] = $bugReport['errors'][0];
         }
         $result = $this->Incidents->createIncidentFromBugReport($bugReport);
 
@@ -378,9 +378,9 @@ class IncidentsTableTest extends TestCase
         $bugReport = file_get_contents(TESTS . 'Fixture' . DS . 'report_js.json');
         $bugReport = json_decode($bugReport, true);
 
-        // Forcefully inflate the report by inflating $bugReport['errors']
+        // Forcefully inflate the report by inflating $bugReport['exception']['stack']
         for ($i = 0; $i < 1500; $i++) {
-            $bugReport['exception']['stack'] .= array_push($bugReport['exception']['stack'][0]);
+            $bugReport['exception']['stack'][] = $bugReport['exception']['stack'][0];
         }
         $result = $this->Incidents->createIncidentFromBugReport($bugReport);
 


### PR DESCRIPTION
The text field in MySQL database holds 65535 characters maximum. If the length of
submitted incident is more than that, most likely it will throw an error and truncate
the data anyway.

Related to #137, #138, #140

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>