### PR TITLE
Follow Github issue state

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ The obtained cliend ID and secret should be stored in the ``config/oauth.php``.
 
 [gh-oauth]: https://github.com/settings/applications
 
+
+## Github Events ##
+- Add a [webhook](https://developer.github.com/webhooks/creating/) at your [target repository](https://github.com/phpmyadmin/phpmyadmin) with payload URL as `https://<host>:<port>/events`
+  - Select content-type as `application/json`
+  - Select `Issues` events from available events
+  - Set the secret token value
+
+- Set the appropriate value of secret token in app.php (same as what you set while setting up the webhook)
+
 # How to run the test suite #
 
 If you are on a development machine you can use the webrunner at `/test.php`

--- a/config/app_example.php
+++ b/config/app_example.php
@@ -330,5 +330,6 @@ return [
 
     'NotificationEmailTo' => 'developers@phpmyadmin.net',
     'NotificationEmailFrom' => 'developers@phpmyadmin.net',
-    'NotificationEmailsTransport' => 'default'
+    'NotificationEmailsTransport' => 'default',
+    'GithubWebhookSecret' => 'test-pma-ers-1'
 ];

--- a/config/app_travis.php
+++ b/config/app_travis.php
@@ -329,5 +329,6 @@ return [
 
     'NotificationEmailsTo' => 'reports-notify@phpmyadmin.net',
     'NotificationEmailsFrom' => 'reports-notify@phpmyadmin.net',
-    'NotificationEmailsTransport' => 'test'
+    'NotificationEmailsTransport' => 'test',
+    'GithubWebhookSecret' => 'test-pma-ers-1'
 ];

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -45,6 +45,7 @@ class AppController extends Controller
         'Incidents' => array(
             'create',
         ),
+        'Events'
     );
 
     public $css_files = array(

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -1,0 +1,215 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+
+/**
+ * Events controller Github webhook events
+ *
+ * phpMyAdmin Error reporting server
+ * Copyright (c) phpMyAdmin project (https://www.phpmyadmin.net/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) phpMyAdmin project (https://www.phpmyadmin.net/)
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ *
+ * @see      https://www.phpmyadmin.net/
+ */
+
+namespace App\Controller;
+
+use Cake\Core\Configure;
+use Cake\Event\Event;
+use Cake\Log\Log;
+use Cake\ORM\TableRegistry;
+
+/**
+ * Events controller Github webhook events
+ */
+class EventsController extends AppController
+{
+
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Csrf');
+
+        $this->Reports = TableRegistry::get('Reports');
+    }
+
+    public function beforeFilter(Event $event)
+    {
+        $this->eventManager()->off($this->Csrf);
+    }
+
+    public function index()
+    {
+        // Only allow POST requests
+        $this->request->allowMethod(['post']);
+
+        // Validate request
+        if (($statusCode = $this->_validateRequest($this->request)) !== 201) {
+            Log::error(
+                'Could not validate the request. Sending a '
+                    . $statusCode . ' response.'
+            );
+
+            // Send a response
+            $this->auto_render = false;
+            $this->response->statusCode($statusCode);
+
+            return $this->response;
+        }
+
+        $issuesData = $this->request->input('json_decode', true);
+        $eventAction = $issuesData['action'];
+        $issueNumber = $issuesData['issue'] ? $issuesData['issue']['number'] : '';
+
+        if ($eventAction === 'closed'
+            || $eventAction === 'opened'
+            || $eventAction === 'reopened'
+        ) {
+            $status = $this->_getAppropriateStatus($eventAction);
+
+            if (($reportsUpdated = $this->Reports->setLinkedReportStatus($issueNumber, $status)) > 0) {
+                Log::debug(
+                    $reportsUpdated . ' linked reports to issue number '
+                        . $issueNumber . ' were updated according to recieved action '
+                        . $eventAction
+                );
+            } else {
+                Log::info(
+                    'No linked report found for issue number \'' . $issueNumber
+                    . '\'. Ignoring the event.'
+                );
+                $statusCode = 204;
+                print_r('asd ' . $issueNumber . ' ' . $eventAction);
+            }
+        } else {
+            Log::info(
+                'Recieved a webhook event for action \'' . $eventAction
+                . '\' on issue number ' . $issueNumber . '. Ignoring the event.'
+            );
+            $statusCode = 204;
+        }
+
+        // Send a response
+        $this->auto_render = false;
+        $this->response->statusCode($statusCode);
+
+        return $this->response;
+    }
+
+
+    /**
+     * Validate HTTP Request recieved
+     *
+     * @param Request $request Request object
+     *
+     * @return int status code based on if this is a valid request
+     */
+    protected function _validateRequest($request)
+    {
+        // Default $statusCode
+        $statusCode = 201;
+
+        $userAgent = $request->getHeaderLine('User-Agent');
+        $eventType = $request->getHeaderLine('X-GitHub-Event');
+
+        $recievedHashHeader = $request->getHeaderLine('X-Hub-Signature');
+        $algo = '';
+        $recievedHash = '';
+        if ($recievedHashHeader !== NULL) {
+            $parts = explode('=', $recievedHashHeader);
+            if (count($parts) > 1) {
+                $algo = $parts[0];
+                $recievedHash = $parts[1];
+            }
+        }
+
+        $expectedHash = $this->_getHash(file_get_contents('php://input'), $algo);
+
+        if ($userAgent !== NULL && strpos($userAgent, 'GitHub-Hookshot') !== 0) {
+            // Check if the User-agent is Github
+            // Otherwise, Send a '403: Forbidden'
+
+            Log::error(
+                'Invalid User agent: ' . $userAgent
+                . '. Ignoring the event.'
+            );
+            $statusCode = 403;
+
+            return $statusCode;
+        } elseif ($eventType !== NULL && $eventType !== 'issues') {
+            // Check if the request is based on 'issues' event
+            // Otherwise, Send a '400: Bad Request'
+
+            Log::error(
+                'Unexpected event type: ' . $eventType
+                . '. Ignoring the event.'
+            );
+            $statusCode = 400;
+
+            return $statusCode;
+        } elseif ($recievedHash !== $expectedHash) {
+            // Check if hash matches
+            // Otherwise, Send a '401: Unauthorized'
+
+            Log::error(
+                'Recieved hash ' . $recievedHash . ' does not match '
+                . ' expected hash ' . $expectedHash
+                . '. Ignoring the event.'
+            );
+            $statusCode = 401;
+
+            return $statusCode;
+        }
+
+        return $statusCode;
+    }
+
+    /**
+     * Get the hash of raw POST payload
+     *
+     * @param string $payload Raw POST body string
+     * @param string $algo    Algorithm used to calculate the hash
+     *
+     * @return string Hmac Digest-based hash of payload
+     */
+    protected function _getHash($payload, $algo)
+    {
+        if ($algo === '') {
+            return '';
+        }
+        $key = Configure::read('GithubWebhookSecret');
+
+        return hash_hmac($algo, $payload, $key);
+    }
+
+    /**
+     * Get appropriate new status based on action recieved in github event
+     *
+     * @param string $action Action recieved in Github webhook event
+     *
+     * @return string Appropriate new status for the related reports
+     */
+    protected function _getAppropriateStatus($action)
+    {
+        $status = 'forwarded';
+
+        switch ($action) {
+            case 'opened':
+                break;
+
+            case 'reopened':
+                break;
+
+            case 'closed':
+                $status = 'resolved';
+                break;
+        }
+
+        return $status;
+    }
+}

--- a/src/Model/Table/ReportsTable.php
+++ b/src/Model/Table/ReportsTable.php
@@ -290,6 +290,26 @@ class ReportsTable extends Table
     }
 
     /**
+     * Updates the linked reports to a Github issue to newly recieved status
+     *
+     * @param string $issueNumber Github Issue number
+     * @param string $status      New status to be set
+     *
+     * @return int Number of Linked reports updated
+     */
+    public function setLinkedReportStatus($issueNumber, $status)
+    {
+        $conditions = array(
+            'sourceforge_bug_id' =>  $issueNumber
+        );
+        $fields = array(
+            'status' => $status
+        );
+
+        return $this->updateAll($fields, $conditions);
+    }
+
+    /**
      * returns an array of conditions that would return all related incidents to the
      * current report.
      *

--- a/tests/TestCase/Controller/EventsControllerTest.php
+++ b/tests/TestCase/Controller/EventsControllerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Test\TestCase\Controller;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\IntegrationTestCase;
+
+class EventsControllerTest extends IntegrationTestCase
+{
+    public $fixtures = array('app.reports');
+
+    public function setUp()
+    {
+        $this->Reports = TableRegistry::get('Reports');
+    }
+
+    public function testIndex()
+    {
+
+        /* Test case 1 */
+        // Invalid User Agent
+        $this->configRequest([
+            'headers' => ['User-Agent' => 'Invalid-GitHub-Hookshot-abcdef']
+        ]);
+        $this->post('/events');
+        $this->assertResponseCode(403);
+
+        /* Test case 2 */
+        // Invalid Event Type
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'anything-except-issues'
+            ]
+        ]);
+        $this->post('/events');
+        $this->assertResponseCode(400);
+
+        /* Test case 3 */
+        // Invalid Hash in headers
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=89db05030cf4c1fbcfb4d590deda30fa40a247ed'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'closed',
+                    'issue' => array(
+                        'number' => 4
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(401);
+
+        /* Test case 4 */
+        // Invalid issues action
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=ddcf5dadbbb716e43da25344989dde547c6c3a03'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'anything-invalid',
+                    'issue' => array(
+                        'number' => 4
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(204);
+
+        /* Test case 5 */
+        // Event for an unlinked issue
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=ddcf5dadbbb716e43da25344989dde547c6c3a03'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'closed',
+                    'issue' => array(
+                        'number' => 1234
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(204);
+
+        // Prepare for testcase
+        $report = $this->Reports->get(4);
+        $report->status = 'resolved';
+        $this->Reports->save($report);
+
+        /* Test case 6 */
+        // Event 'opened' for a linked issue
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=ddcf5dadbbb716e43da25344989dde547c6c3a03'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'opened',
+                    'issue' => array(
+                        'number' => 4
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(201);
+        $report = $this->Reports->get(4);
+        $this->assertEquals($report->status, 'forwarded');
+
+
+        /* Test case 7 */
+        // Event 'closed' for a linked issue
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=ddcf5dadbbb716e43da25344989dde547c6c3a03'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'closed',
+                    'issue' => array(
+                        'number' => 4
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(201);
+        $report = $this->Reports->get(4);
+        $this->assertEquals($report->status, 'resolved');
+
+        // Prepare for testcase
+        $report = $this->Reports->get(4);
+        $report->status = 'resolved';
+        $this->Reports->save($report);
+
+        /* Test case 8 */
+        // Event 'reopened' for a linked issue
+        $this->configRequest([
+            'headers' => [
+                'User-Agent' => 'GitHub-Hookshot-abcdef',
+                'X-GitHub-Event' => 'issues',
+                'X-Hub-Signature' => 'sha1=ddcf5dadbbb716e43da25344989dde547c6c3a03'
+            ]
+        ]);
+        $this->post(
+            '/events',
+            json_encode(
+                array(
+                    'action' => 'reopened',
+                    'issue' => array(
+                        'number' => 4
+                    )
+                )
+            )
+        );
+        $this->assertResponseCode(201);
+        $report = $this->Reports->get(4);
+        $this->assertEquals($report->status, 'forwarded');
+    }
+}


### PR DESCRIPTION
Fix #98

* Follow Github issue state
* Add tests for Github events controller

To setup:
* Add a webhook (ref:https://developer.github.com/webhooks/creating/) at https://github.com/phpmyadmin/phpmyadmin with URL as `https://reports.phpmyadmin.net/events`
* Set the appropriate value of secret token in app.php
* Select content-type as application/json
* Select `Issues` events from available events

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>