### PR TITLE
Partially fix error introduced in 66d9f09

### DIFF
--- a/config/Migrations/20170530155816_fix_stale_report_states.php
+++ b/config/Migrations/20170530155816_fix_stale_report_states.php
@@ -19,13 +19,13 @@ class FixStaleReportStates extends AbstractMigration
 
     private function _migrateBasedOnGithubLinked()
     {
-        $sql = 'UPDATE `reports` SET `status` = \'resolved\''
+        $sql = 'UPDATE `reports` SET `status` = \'forwarded\''
             . ' WHERE `sourceforge_bug_id` IS NOT NULL AND `status` <> \'fixed\'';
         $rowsAffected = $this->execute($sql);
 
         Log::debug(
-            $rowsAffected . ' reports are linked to an'
-                . ' open Github issue.'
+            $rowsAffected . ' reports are linked to a'
+                . ' Github issue.'
                 . ' These have been marked to have a \'forwarded\' status.'
         );
     }

--- a/src/Model/Table/ReportsTable.php
+++ b/src/Model/Table/ReportsTable.php
@@ -75,7 +75,8 @@ class ReportsTable extends Table
     public $status = array(
         'new' => 'New',
         'invalid' => 'Invalid',
-        'resolved' => 'Resolved'
+        'resolved' => 'Resolved',
+        'forwarded' => 'Forwarded'
     );
 
     public function initialize(array $config)


### PR DESCRIPTION
Once #160 is fixed, we might be able to recover some data

Moreover the absence of `forwarded` in `Reports->status` array might be actually causing the behaviour in #158 

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>