### PR TITLE
Fix #175: Broken phpMyAdmin version string stripping

### DIFF
--- a/src/Controller/NotificationsController.php
+++ b/src/Controller/NotificationsController.php
@@ -76,7 +76,6 @@ class NotificationsController extends AppController
             ),
             'order' => $orderConditions,
         );
-        //$current_developer = Sanitize::clean($current_developer);
 
         $pagedParams = $params;
         $pagedParams['limit'] = intval($this->request->query('iDisplayLength'));

--- a/src/Model/Table/IncidentsTable.php
+++ b/src/Model/Table/IncidentsTable.php
@@ -308,7 +308,6 @@ class IncidentsTable extends Table
                 'status' => 'new',
                 'location' => $location,
                 'linenumber' => is_null($linenumber) ? 0 : $linenumber,
-                'pma_version' => $bugReport['pma_version'],
                 'pma_version' => $this->getStrippedPmaVersion($bugReport['pma_version']),
                 'exception_type' => $exception_type,
             )

--- a/src/Model/Table/IncidentsTable.php
+++ b/src/Model/Table/IncidentsTable.php
@@ -309,6 +309,7 @@ class IncidentsTable extends Table
                 'location' => $location,
                 'linenumber' => is_null($linenumber) ? 0 : $linenumber,
                 'pma_version' => $bugReport['pma_version'],
+                'pma_version' => $this->getStrippedPmaVersion($bugReport['pma_version']),
                 'exception_type' => $exception_type,
             )
         );

--- a/tests/Fixture/report_js.json
+++ b/tests/Fixture/report_js.json
@@ -46,9 +46,9 @@
         "useragent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36",
         "uri": "tbl_structure.php?target="
     },
-		"steps": "<script>test steps",
+    "steps": "<script>test steps",
     "script_name": "tbl_relation.php",
-    "pma_version": "4.0",
+    "pma_version": "4.5.4.1deb2ubuntu2",
     "browser_name": "FIREFOX",
     "browser_version": "17.5",
     "user_os": "Windows",

--- a/tests/Fixture/report_php.json
+++ b/tests/Fixture/report_php.json
@@ -1,58 +1,62 @@
 {
-	"pma_version": "4.3.0-dev",
-	"browser_name": "CHROME",
-	"browser_version": "27.0.1453.93",
-	"user_os":"Linux",
-	"server_software":"Apache\/2.4.9 (Unix) OpenSSL\/1.0.1g PHP\/5.5.11 mod_perl\/2.0.8-dev Perl\/v5.16.3",
-	"user_agent_string":"Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.93 Safari\/537.36",
-	"locale":"en",
-	"configuration_storage": "disabled",
-	"php_version": "5.5.11",
-	"exception_type": "php",
-	"errors":[
-		{
-			"lineNum":1771,
-			"file":".\/libraries\/Config.class.php",
-			"type":"Notice",
-			"msg":"Undefined variable: haha",
-			"stackTrace":[
-				{
-					"file":"\/opt\/lampp\/htdocs\/phpmyadmin-new\/index.php",
-					"line":228,
-					"function":"getFontsizeForm",
-					"class":"PMA_Config",
-					"type":"::",
-					"args":[]
-				}
-			],
-			"stackhash":"5063bbe81a2daa6a6ad39c5cd315701c"
-		},
-		{
-			"lineNum":557,
-			"file":".\/libraries\/Util.class.php",
-			"type":"Notice",
-			"msg":"Undefined variable: hihi",
-			"stackTrace":[
-				{
-					"file":"\/opt\/lampp\/htdocs\/phpmyadmin-new\/index.php",
-					"line":322,
-					"function":"showPHPDocu",
-					"class":"PMA_Util",
-					"type":"::",
-					"args":[
-						"book.mysqli.php"
-					]
-				}
-			],
-			"stackhash":"e911a21765eae766463612e033773716"
-		},
-		{
-			"lineNum":665,
-			"file":".\/index.php",
-			"type":"Notice",
-			"msg":"Undefined variable: hehe",
-			"stackTrace":[],
-			"stackhash":"37848b23bdd6e737273516b9575fe407"
-		}
-	]
+    "pma_version": "4.5.4.1deb2ubuntu2",
+    "browser_name": "CHROME",
+    "browser_version": "27.0.1453.93",
+    "user_os": "Linux",
+    "server_software": "Apache\/2.4.9 (Unix) OpenSSL\/1.0.1g PHP\/5.5.11 mod_perl\/2.0.8-dev Perl\/v5.16.3",
+    "user_agent_string": "Mozilla\/5.0 (X11; Linux i686) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/27.0.1453.93 Safari\/537.36",
+    "locale": "en",
+    "configuration_storage": "disabled",
+    "php_version": "5.5.11",
+    "exception_type": "php",
+    "errors": [
+        {
+            "lineNum": 1771,
+            "file": ".\/libraries\/Config.class.php",
+            "type": "Notice",
+            "msg": "Undefined variable: haha",
+            "stackTrace": [
+                {
+                    "file": "\/opt\/lampp\/htdocs\/phpmyadmin-new\/index.php",
+                    "line": 228,
+                    "function": "getFontsizeForm",
+                    "class": "PMA_Config",
+                    "type": ":: ",
+                    "args": [
+
+                    ]
+                }
+            ],
+            "stackhash": "5063bbe81a2daa6a6ad39c5cd315701c"
+        },
+        {
+            "lineNum": 557,
+            "file": ".\/libraries\/Util.class.php",
+            "type": "Notice",
+            "msg": "Undefined variable: hihi",
+            "stackTrace": [
+                {
+                    "file": "\/opt\/lampp\/htdocs\/phpmyadmin-new\/index.php",
+                    "line": 322,
+                    "function": "showPHPDocu",
+                    "class": "PMA_Util",
+                    "type": ":: ",
+                    "args": [
+                        "book.mysqli.php"
+                    ]
+                }
+            ],
+            "stackhash": "e911a21765eae766463612e033773716"
+        },
+        {
+            "lineNum": 665,
+            "file": ".\/index.php",
+            "type": "Notice",
+            "msg": "Undefined variable: hehe",
+            "stackTrace": [
+
+            ],
+            "stackhash": "37848b23bdd6e737273516b9575fe407"
+        }
+    ]
 }

--- a/tests/TestCase/Controller/IncidentsControllerTest.php
+++ b/tests/TestCase/Controller/IncidentsControllerTest.php
@@ -109,8 +109,10 @@ class IncidentsControllerTest extends IntegrationTestCase
                 $report['error_message']);
         $this->assertEquals($bugReportDecoded['exception']['name'],
                 $report['error_name']);
-        $this->assertEquals($bugReportDecoded['pma_version'],
-                $report['pma_version']);
+        $this->assertEquals(
+            $this->Incidents->getStrippedPmaVersion($bugReportDecoded['pma_version']),
+            $report['pma_version']
+        );
 
         $this->configRequest(array('input' => ''));
         $this->post('/incidents/create');

--- a/tests/TestCase/Controller/IncidentsControllerTest.php
+++ b/tests/TestCase/Controller/IncidentsControllerTest.php
@@ -55,15 +55,15 @@ class IncidentsControllerTest extends IntegrationTestCase
                 'stacktrace' => array(array('context' => array('test'))),
                 'full_report' => array(
                     'pma_version' => '',
-          'php_version' => '',
-          'browser_name' => '',
-          'browser_version' => '',
-          'user_agent_string' => '',
-          'server_software' => '',
-          'locale' => '',
-          'exception' => array('uri' => ''),
-          'configuration_storage' => '',
-          'microhistory' => '',
+                    'php_version' => '',
+                    'browser_name' => '',
+                    'browser_version' => '',
+                    'user_agent_string' => '',
+                    'server_software' => '',
+                    'locale' => '',
+                    'exception' => array('uri' => ''),
+                    'configuration_storage' => '',
+                    'microhistory' => '',
                 ),
                 'report_id' => 1,
                 'created' => '2013-08-29T18:10:01',
@@ -86,6 +86,7 @@ class IncidentsControllerTest extends IntegrationTestCase
         $subject = 'A new report has been submitted '
             . 'on the Error Reporting Server: '
             . $report['id'];
+        $this->assertEquals('4.5.4.1', $report['pma_version']);
 
         // Test notification email
         $emailContent = Configure::read('test_transport_email');
@@ -100,7 +101,6 @@ class IncidentsControllerTest extends IntegrationTestCase
 
         $report = $this->Reports->find('all',
                 array('order' => 'Reports.created desc'))->all()->first();
-        //$report = $report->hydrate(false)->toArray();
         $this->Reports->id = $report['id'];
         $incidents = $this->Reports->getIncidents();
         $incidents = $incidents->hydrate(false)->toArray();
@@ -111,12 +111,11 @@ class IncidentsControllerTest extends IntegrationTestCase
                 $report['error_name']);
         $this->assertEquals($bugReportDecoded['pma_version'],
                 $report['pma_version']);
+
         $this->configRequest(array('input' => ''));
         $this->post('/incidents/create');
         $result = json_decode($this->_response->body(), true);
         $this->assertEquals(false, $result['success']);
-
-
 
         // Test invalid Notification email configuration
         Configure::write('NotificationEmailsTo', '');
@@ -131,6 +130,7 @@ class IncidentsControllerTest extends IntegrationTestCase
         $subject = 'A new report has been submitted '
             . 'on the Error Reporting Server: '
             . $report['id'];
+        $this->assertEquals('4.5.4.1', $report['pma_version']);
 
         $emailContent = Configure::read('test_transport_email');
 

--- a/tests/TestCase/Model/Table/IncidentsTableTest.php
+++ b/tests/TestCase/Model/Table/IncidentsTableTest.php
@@ -182,7 +182,7 @@ class IncidentsTableTest extends TestCase
 
         $expected = array(
             array(
-                'pma_version' => '4.0',
+                'pma_version' => '4.5.4.1',
                 'php_version' => '5.2',
                 'steps' => '<script>test steps',
                 'error_message' => 'a is not defined',
@@ -211,7 +211,7 @@ class IncidentsTableTest extends TestCase
 
         $expected = array(
             array(
-                'pma_version' => '4.3.0-dev',
+                'pma_version' => '4.5.4.1',
                 'php_version' => '5.5',
                 'error_message' => 'Undefined variable: haha',
                 'error_name' => 'Notice',
@@ -227,7 +227,7 @@ class IncidentsTableTest extends TestCase
                 'exception_type' => 1,
             ),
             array(
-                'pma_version' => '4.3.0-dev',
+                'pma_version' => '4.5.4.1',
                 'php_version' => '5.5',
                 'error_message' => 'Undefined variable: hihi',
                 'error_name' => 'Notice',
@@ -243,7 +243,7 @@ class IncidentsTableTest extends TestCase
                 'exception_type' => 1,
             ),
             array(
-                'pma_version' => '4.3.0-dev',
+                'pma_version' => '4.5.4.1',
                 'php_version' => '5.5',
                 'error_message' => 'Undefined variable: hehe',
                 'error_name' => 'Notice',
@@ -281,7 +281,7 @@ class IncidentsTableTest extends TestCase
             'status' => 'new',
             'location' => 'error.js',
             'linenumber' => (int) 312,
-            'pma_version' => '4.0',
+            'pma_version' => '4.5.4.1',
             'exception_type' => 0,
         );
 
@@ -300,7 +300,7 @@ class IncidentsTableTest extends TestCase
             'status' => 'new',
             'location' => './libraries/Util.class.php',
             'linenumber' => (int) 557,
-            'pma_version' => '4.3.0-dev',
+            'pma_version' => '4.5.4.1',
             'exception_type' => 1,
         );
         $this->assertEquals($expected, $result);
@@ -446,6 +446,7 @@ class IncidentsTableTest extends TestCase
             array('4.1.6deb0ubuntu1ppa1', '4.1.6'),
             array('4.2.3deb1.trusty~ppa.1', '4.2.3'),
             array('4.2.9deb0.1', '4.2.9'),
+            array('4.5.4.1deb2ubuntu2', '4.5.4.1')
         );
     }
 }


### PR DESCRIPTION
Strip `pma_version` correctly while creating a new report too

Fix #175 
Also,
* Add related tests to IncidentsControllerTest
* Fix json formatting of incidents

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>



